### PR TITLE
docs: add story sort order

### DIFF
--- a/packages/storybook/config/preview.ts
+++ b/packages/storybook/config/preview.ts
@@ -4,7 +4,12 @@ import type { Preview } from '@storybook/react';
 const preview: Preview = {
   parameters: {
     controls: { expanded: false },
-    options: { panelPosition: 'right' },
+    options: {
+      panelPosition: 'right',
+      storySort: {
+        order: ['VNG', 'Templates'],
+      },
+    },
   },
 };
 


### PR DESCRIPTION
Ensures docs are ordered before templates in the storybook sidenav

<img width="396" alt="image" src="https://github.com/user-attachments/assets/ebea93ca-830e-4a7e-8170-8d77bc86590a">

