### PR TITLE
feat: add login page

### DIFF
--- a/packages/storybook/src/templates/form-wmebv/components/Layout.tsx
+++ b/packages/storybook/src/templates/form-wmebv/components/Layout.tsx
@@ -1,0 +1,54 @@
+import {
+  Heading2,
+  Link,
+  LinkList,
+  LinkListLink,
+  PageContent,
+  PageFooter,
+  PageHeader,
+} from '@utrecht/component-library-react/dist/css-module';
+import { HTMLAttributes, PropsWithChildren } from 'react';
+import { Logo, PageHeaderLogo } from './Logo';
+
+export const Layout = ({ children, className, ...props }: PropsWithChildren<HTMLAttributes<HTMLDivElement>>) => {
+  return (
+    <div className={`utrecht-document ${className}`} {...props}>
+      <PageHeader className="voorbeeld-page-header">
+        <div className="todo-page-header__content">
+          <PageHeaderLogo />
+        </div>
+      </PageHeader>
+      <PageContent className="todo-page-content">
+        <main className={'utrecht-page-content__main'}>{children}</main>
+      </PageContent>
+      <PageFooter>
+        <div className="todo-page-footer__content">
+          <div className="todo-footer-content-group">
+            <div className="todo-footer-content-block">
+              <Logo />
+            </div>
+            <div className="todo-footer-content-block">
+              <Heading2>Contact</Heading2>
+              <address className="todo-address utrecht-paragraph">
+                Bel <Link href="tel:453453">453 453</Link> (maandag tot en met vrijdag van 09.00 tot 17.00 uur) of stuur
+                een e-mail naar{' '}
+                <Link href="mailto:vragen@gemeentevoorbeeld.nl">
+                  <span className="utrecht-url-data">vragen@gemeentevoorbeeld.nl</span>
+                </Link>
+                {'.'}
+              </address>
+            </div>
+            <div className="todo-footer-content-block">
+              <LinkList>
+                <LinkListLink href="/">Bescherming persoonsgegevens</LinkListLink>
+                <LinkListLink href="/">Gebruikersvoorwaarden</LinkListLink>
+                <LinkListLink href="/">Proclaimer</LinkListLink>
+                <LinkListLink href="/">Cookieverklaring</LinkListLink>
+              </LinkList>
+            </div>
+          </div>
+        </div>
+      </PageFooter>
+    </div>
+  );
+};

--- a/packages/storybook/src/templates/form-wmebv/wmebv-1-intro.stories.tsx
+++ b/packages/storybook/src/templates/form-wmebv/wmebv-1-intro.stories.tsx
@@ -3,14 +3,8 @@ import { IconArrowLeft } from '@tabler/icons-react';
 import {
   ButtonLink,
   Heading1,
-  Heading2,
   Icon,
   Link,
-  LinkList,
-  LinkListLink,
-  PageContent,
-  PageFooter,
-  PageHeader,
   Paragraph,
   UnorderedList,
   UnorderedListItem,
@@ -18,7 +12,7 @@ import {
 import '@nl-design-system-unstable/voorbeeld-design-tokens/dist/index.css';
 import '@gemeente-denhaag/design-tokens-components/dist/theme/index.css';
 import './index.css';
-import { Logo, PageHeaderLogo } from './components/Logo';
+import { Layout } from './components/Layout';
 
 const meta = {
   title: 'Templates/WMEBV/1 - Intro',
@@ -33,68 +27,28 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const TemplatePage = ({ theme }: { theme: string }) => (
-  <>
-    <div className={`utrecht-document ${theme}`}>
-      <PageHeader className="voorbeeld-page-header">
-        <div className="todo-page-header__content">
-          <PageHeaderLogo />
-        </div>
-      </PageHeader>
-      <PageContent className="todo-page-content">
-        <main className={'utrecht-page-content__main'}>
-          <Link href="/#" className="voorbeeld-back-link">
-            <Icon>
-              <IconArrowLeft />
-            </Icon>
-            Terug
-          </Link>
-          <Heading1>Vraag aan de gemeente</Heading1>
-          <Paragraph lead>
-            Veel zaken regelt u eenvoudig zelf online via onze website. Kunt u de gewenste informatie niet vinden? Stel
-            dan uw vraag via het contactformulier.
-          </Paragraph>
-          <UnorderedList>
-            <UnorderedListItem>Het duurt ongeveer 5 minuten om dit formulier in te vullen.</UnorderedListItem>
-            <UnorderedListItem>Vul alle velden in. Als een veld niet verplicht is, staat dit erbij.</UnorderedListItem>
-            <UnorderedListItem>U kunt het formulier tussentijds opslaan en later verder gaan.</UnorderedListItem>
-            <UnorderedListItem>
-              Na het versturen ontvangt u een bevestigingsmail. Ook heeft u de mogelijkheid uw vraag te downloaden of
-              printen.
-            </UnorderedListItem>
-          </UnorderedList>
-          <ButtonLink appearance="primary-action-button">Doorgaan</ButtonLink>
-        </main>
-      </PageContent>
-      <PageFooter>
-        <div className="todo-page-footer__content">
-          <div className="todo-footer-content-group">
-            <div className="todo-footer-content-block">
-              <Logo />
-            </div>
-            <div className="todo-footer-content-block">
-              <Heading2>Contact</Heading2>
-              <address className="todo-address utrecht-paragraph">
-                Bel <Link href="tel:453453">453 453</Link> (maandag tot en met vrijdag van 09.00 tot 17.00 uur) of stuur
-                een e-mail naar{' '}
-                <Link href="mailto:vragen@gemeentevoorbeeld.nl">
-                  <span className="utrecht-url-data">vragen@gemeentevoorbeeld.nl</span>
-                </Link>
-                {'.'}
-              </address>
-            </div>
-            <div className="todo-footer-content-block">
-              <LinkList>
-                <LinkListLink href="/">Bescherming persoonsgegevens</LinkListLink>
-                <LinkListLink href="/">Gebruikersvoorwaarden</LinkListLink>
-                <LinkListLink href="/">Proclaimer</LinkListLink>
-                <LinkListLink href="/">Cookieverklaring</LinkListLink>
-              </LinkList>
-            </div>
-          </div>
-        </div>
-      </PageFooter>
-    </div>
-  </>
+  <Layout className={theme}>
+    <Link href="/#" className="voorbeeld-back-link">
+      <Icon>
+        <IconArrowLeft />
+      </Icon>
+      Terug
+    </Link>
+    <Heading1>Vraag aan de gemeente</Heading1>
+    <Paragraph lead>
+      Veel zaken regelt u eenvoudig zelf online via onze website. Kunt u de gewenste informatie niet vinden? Stel dan uw
+      vraag via het contactformulier.
+    </Paragraph>
+    <UnorderedList>
+      <UnorderedListItem>Het duurt ongeveer 5 minuten om dit formulier in te vullen.</UnorderedListItem>
+      <UnorderedListItem>Vul alle velden in. Als een veld niet verplicht is, staat dit erbij.</UnorderedListItem>
+      <UnorderedListItem>U kunt het formulier tussentijds opslaan en later verder gaan.</UnorderedListItem>
+      <UnorderedListItem>
+        Na het versturen ontvangt u een bevestigingsmail. Ook heeft u de mogelijkheid uw vraag te downloaden of printen.
+      </UnorderedListItem>
+    </UnorderedList>
+    <ButtonLink appearance="primary-action-button">Doorgaan</ButtonLink>
+  </Layout>
 );
 
 export const Default: Story = {

--- a/packages/storybook/src/templates/form-wmebv/wmebv-2-login.stories.tsx
+++ b/packages/storybook/src/templates/form-wmebv/wmebv-2-login.stories.tsx
@@ -1,0 +1,58 @@
+import { Meta, StoryObj } from '@storybook/react';
+import '@nl-design-system-unstable/voorbeeld-design-tokens/dist/index.css';
+import '@gemeente-denhaag/design-tokens-components/dist/theme/index.css';
+import './index.css';
+import { IconArrowLeft } from '@tabler/icons-react';
+import {
+  Button,
+  ButtonGroup,
+  Heading1,
+  Heading2,
+  Icon,
+  Link,
+  Paragraph,
+} from '@utrecht/component-library-react/dist/css-module';
+import { Layout } from './components/Layout';
+
+const meta = {
+  title: 'Templates/WMEBV/2 - Login',
+  id: 'wmebv-2-intro',
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const TemplatePage = ({ theme }: { theme: string }) => (
+  <>
+    <Layout className={theme}>
+      <Link href="/#" className="voorbeeld-back-link">
+        <Icon>
+          <IconArrowLeft />
+        </Icon>
+        Terug
+      </Link>
+      <Heading1>Vraag aan de gemeente</Heading1>
+      <Heading2>Inloggen</Heading2>
+      <Paragraph>
+        Dankzij uw DigiD kunt u overal makkelijk en veilig inloggen. Uw persoonlijke gegevens blijven goed beschermd.
+        Wanneer u inlogt worden uw persoonlijke gegevens automatisch ingevuld.
+      </Paragraph>
+      <ButtonGroup>
+        <Button>Inloggen</Button>
+        <Button>Verder gaan zonder inloggen</Button>
+      </ButtonGroup>
+    </Layout>
+  </>
+);
+
+export const Default: Story = {
+  render: () => <TemplatePage theme={'voorbeeld-theme'} />,
+};
+
+export const DenHaagTheme: Story = {
+  render: () => <TemplatePage theme={'denhaag-theme'} />,
+};


### PR DESCRIPTION
# Description
Adds the login page template to Storybook en refactors page layout so it's reusable in all WMEBV templates. Buttons are temporary.

Closes issues:
- #110 

## New issues encountered
- #154

## Preview
<img width="1705" alt="image" src="https://github.com/user-attachments/assets/fb775979-e8a1-4e77-aaf1-c2533d6bc1e7">
