### PR TITLE
fix: utrecht root import

### DIFF
--- a/packages/storybook/src/components/Layout.tsx
+++ b/packages/storybook/src/components/Layout.tsx
@@ -7,7 +7,7 @@ import {
   PageFooter,
   PageHeader,
 } from '@utrecht/component-library-react/dist/css-module';
-import { Root } from '@utrecht/root-react/dist/css';
+import { Root } from '@utrecht/root-react/dist';
 import { HTMLAttributes, PropsWithChildren, ReactElement } from 'react';
 
 interface LayoutProps extends PropsWithChildren<HTMLAttributes<HTMLDivElement>> {


### PR DESCRIPTION
Font fam werd op sommige componenten niet toegepast. De aangepaste Utrecht Root import lost dit probleem op.